### PR TITLE
shell quoted "cd" path problem

### DIFF
--- a/cmake-project.el
+++ b/cmake-project.el
@@ -192,7 +192,7 @@ directory is found automatically based on the current buffer."
     (let ((default-directory build-directory))
       (compilation-start
        (concat
-        "cd " (shell-quote-argument (expand-file-name build-directory))
+        "cd " (expand-file-name build-directory)
         " && cmake " (shell-quote-argument
                       (expand-file-name source-directory))
         (if (string= "" generator)


### PR DESCRIPTION
compilation-start command parse cd path from "cd {path} && cmake
${path}" string and pass it to elisp (cd PATH) func. With shell quoted
form, the cd elisp function gave error message "No such directory
found via CDPATH environment variable"
