### PR TITLE
Allow to specify additional flags for CMake when 'configuring'.

### DIFF
--- a/cmake-project.el
+++ b/cmake-project.el
@@ -214,7 +214,7 @@ directory is found automatically based on the current buffer."
 (define-minor-mode cmake-project-mode
   "Minor mode that integrates a CMake-based project with Emacs
 build tools such as the CompileCommand and Flymake."
-  :lighter "CMake"
+  :lighter " CMake"
 
   (cond
    ;; Enabling mode


### PR DESCRIPTION
Please check my little patch which fixes a whitespace issue in the modeline and allows to pass additional command line arguments to CMake, like:

cmake -DCMAKE_CXX_COMPILER=... -D.... SOURCE_DIR

This is achieved by adding an optional prefix argument to cmake-project-configure-project which will prompt the user for additional flags for CMake.