### PR TITLE
Fixes for issue #12

### DIFF
--- a/cmake-project.el
+++ b/cmake-project.el
@@ -213,7 +213,11 @@ specified interactively."
          (expand-file-name source-directory))
         (if (string= "" generator)
             ""
-          (concat " -G " (shell-quote-argument generator)))))
+          (concat " -G " (shell-quote-argument
+			  (if (string= (substring generator (- (length generator) 7)) " [arch]")
+			      (substring generator 0 (- (length generator) 7))
+			    (concat generator ""))
+			  )))))
       (cmake-project--changed-build-directory build-directory))))
 
 ;;;###autoload


### PR DESCRIPTION
This fixes the issue I opened a while ago, by removing " [arch]" part of the build command when using Visual Studio compilers.