### PR TITLE
Fixed cmake-project-configure-project

### DIFF
--- a/cmake-project.el
+++ b/cmake-project.el
@@ -178,13 +178,13 @@ prevent a fatal Flymake shutdown."
 (defun cmake-project--available-generators ()
   (let ((help-text (shell-command-to-string "cmake --help"))
         (regexp (concat
-                 "The following generators are available on this platform:\n"
+                 "The following generators are available on this platform.*\n"
                  "\\([^\\']*\\)\\'"))
         (out))
     (string-match regexp help-text)
     (let ((gens-chunk (match-string 1 help-text)))
       (while (string-match
-              "\\s-+\\([^=\n]+?\\)\\s-*=[^\n]+?\n\\([^\\']*\\)\\'" gens-chunk)
+              "\\s-+\\([^=\n]+?\\)\n?\\s-*=[^\n]+?\n\\([^\\']*\\)\\'" gens-chunk)
         (setq out (add-to-list 'out (match-string 1 gens-chunk) 1))
         (setq gens-chunk (match-string 2 gens-chunk)))
       out)))


### PR DESCRIPTION
cmake-project--available-generators was not properly parsing the available generators list from `cmake --help` for versions CMake 3.16 and newer. Fixed the regexes in cmake-project--available-generators to properly parse the newer format generator list.